### PR TITLE
Add static import to scid.nonlinear

### DIFF
--- a/source/scid/nonlinear.d
+++ b/source/scid/nonlinear.d
@@ -12,6 +12,7 @@ import std.algorithm;
 import std.exception;
 import std.functional;
 import std.math;
+static import std.numeric;
 import std.range;
 import std.traits;
 import std.typecons;


### PR DESCRIPTION
There was a missing (static) import of the module std.numeric in the
module scid.nonlinear which caused the following DUB warning:

> source/scid/nonlinear.d(255,15): Deprecation: module std.numeric is not accessible here, perhaps add 'static import std.numeric;'
> source/scid/nonlinear.d(255,15): Deprecation: module std.numeric is not accessible here, perhaps add 'static import std.numeric;'
> source/scid/nonlinear.d(255,15): Deprecation: module std.numeric is not accessible here, perhaps add 'static import std.numeric;'
> source/scid/nonlinear.d(504,16): Deprecation: module std.numeric is not accessible here, perhaps add 'static import std.numeric;'
